### PR TITLE
Fix Issue #10: updated readme to use correct symlink

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ git clone git@github.com:bomberstudios/sketch-framer.git
 2. Download the [Beta version of Sketch](http://www.bohemiancoding.com/sketch/beta/)
 3. Enable scripting in Sketch by going to *Preferences > General* and clicking the *Enable Scripting* button.
 4. In Terminal go to `~/Library/Application Support/sketch/Plugins` (Create these directories if they don't exist) *Note: if you're running the App Store version of Sketch (we suggest the Beta), you should go to this folder instead: `~/Library/Containers/com.bohemiancoding.sketch/Data/Library/Application Support/sketch/Plugins`*
-5. Type `ln -s "~/sketch-framer/sketch-plugin/Sketch Framer" "./Sketch Framer"`
+5. Type `ln -s ~/"sketch-framer/sketch-plugin/Sketch Framer" "./Sketch Framer"`
 6. Now you should see the option in your Plugins menu.
 
 ![Plugins menu](https://f.cloud.github.com/assets/200566/1139282/491116ce-1c88-11e3-807e-e0d8430814d0.png)


### PR DESCRIPTION
The "~" character needs to be outside of the quotes, otherwise it doesn't get expanded to the home folder.
