### PR TITLE
Round X & Y values to whole number. Prevents blurred placements of views...

### DIFF
--- a/sketch-plugin/Sketch Framer/Export to Framer.jstalk
+++ b/sketch-plugin/Sketch Framer/Export to Framer.jstalk
@@ -366,8 +366,8 @@ function calculate_real_position_for(layer) {
       GKRectRulerY = [gkrect y] + rulerDeltaY;
 
   return {
-    x: GKRectRulerX,
-    y: GKRectRulerY
+    x: Math.round(GKRectRulerX),
+    y: Math.round(GKRectRulerY
   }
 }
 function extract_metadata_from(layer) {


### PR DESCRIPTION
Sketch is exporting x & y values as half pixels in certain circumstances. Rounding this to a whole pixel value fixes any blurring when viewed.
