### PR TITLE
Pop the folder if this is the first save

### DIFF
--- a/Export to Framer.sketchplugin
+++ b/Export to Framer.sketchplugin
@@ -473,14 +473,16 @@ function main() {
   [task setArguments:argsArray];
   [task launch];
 
-  // Open HTML in default browser
-  var open_task = [[NSTask alloc] init],
-      open_task_args = [NSArray arrayWithObjects:(target_folder + "/index.html"), nil];
+  // Open HTML in default browser if it's the first time we're exporting
+  if(![file_manager fileExistsAtPath:(target_folder + "/index.html")]) {
+    var open_task = [[NSTask alloc] init],
+        open_task_args = [NSArray arrayWithObjects:(target_folder), nil];
 
-  [open_task setCurrentDirectoryPath:framer_folder];
-  [open_task setLaunchPath:"/usr/bin/open"];
-  [open_task setArguments:open_task_args];
-  [open_task launch];
+    [open_task setCurrentDirectoryPath:framer_folder];
+    [open_task setLaunchPath:"/usr/bin/open"];
+    [open_task setArguments:open_task_args];
+    [open_task launch];
+  }
 
   log('#################################################################################################################################################');
 


### PR DESCRIPTION
Currently sketch-framer opens the exported prototype every time it is saved. On Chrome this creates a new tab every time, which is a bit annoying. Also, I would still have to locate the folder to edit app.js.

I thought to check whether this is the first export of the prototype, and if so, then I pop the entire folder open, so I can access app.js or index.html.
