### PR TITLE
Error messages for known bugs

### DIFF
--- a/Export to Framer.sketchplugin
+++ b/Export to Framer.sketchplugin
@@ -195,13 +195,17 @@ var sandboxAccess = AppSandboxFileAccess.init({
 })
 
 
-if (in_sandbox()) {
+if (show_errors && in_sandbox()) {
   [[NSApplication sharedApplication] displayDialog:"Please use this plugin with Sketch Beta. You can search 'Sketch Beta' in Google to download it.\n\n(Or manually copy framer.js info the framer folder)." withTitle:"Sketch Framer known bugs"]
 }
 
 
 /* Configuration */
 var framerjs_url = "http://rawgit.com/koenbok/Framer/master/build/framer.js";
+
+function major_version() {
+  return [NSApp applicationVersion].substr(0,1);
+}
 
 function should_become_view(layer) {
   return is_group(layer) || [layer name].slice(-1) == '+';
@@ -238,7 +242,7 @@ function export_layer(layer, depth) {
   log_depth("Exporting <" + [layer name] + ">", depth);
   var filename = images_folder + "/" + sanitize_filename([layer name]) + ".png";
 
-  if([layer isMemberOfClass:[MSArtboardGroup class]] && [NSApp applicationVersion] >= 3) {
+  if(show_errors && [layer isMemberOfClass:[MSArtboardGroup class]] && major_version == 3) {
     [[NSApplication sharedApplication] displayDialog:"Sketch Framer currently doesn't support artboards with Sketch 3. Please remove the artboard and have layers directly on the canvas. You can group everything at the top level and move it to (0,0) for intended results." withTitle:"Sketch Framer known bugs"]
   }
 

--- a/sketch-framer-config.js
+++ b/sketch-framer-config.js
@@ -13,7 +13,7 @@
 */
 
 var FramerLibraryUrl;
-
+var show_errors = true;
 
 
 


### PR DESCRIPTION
We currently don't support the app store version of sketch because it's not able to download framer.js from the server. A lot of people seem to be confused about this so I thought the plugin could emit an error message for now.

Likewise artboards in sketch 3 don't work, so I added an error message for that too.
